### PR TITLE
feat: add dynamic rate-limiter for requests

### DIFF
--- a/src/Classes/TradeQueryRateLimiter.lua
+++ b/src/Classes/TradeQueryRateLimiter.lua
@@ -1,0 +1,265 @@
+-- Path of Building
+--
+-- Module: Trade Site Rate Limiter
+-- Manages rate limits for trade API
+-- https://www.pathofexile.com/forum/view-thread/2079853
+--
+
+---@class TradeQueryRateLimiter
+local TradeQueryRateLimiterClass = newClass("TradeQueryRateLimiter", function(self)
+    -- policies_sample = {
+    -- --   label: policy
+    --     ["trade-search-request-limit"] = {
+    -- --       label: rule   
+    --         ["Ip"] = {
+    --             ["state"] = {
+    --                 ["60"]  = {["timeout"] = 0,    ["request"] = 1},
+    --                 ["300"] = {["timeout"] = 0,    ["request"] = 1},
+    --                 ["10"]  = {["timeout"] = 0,    ["request"] = 1}
+    --             },
+    --             ["limits"] = {
+    --                 ["60"]  = {["timeout"] = 120,  ["request"] = 15},
+    --                 ["300"] = {["timeout"] = 1800, ["request"] = 60},
+    --                 ["10"]  = {["timeout"] = 60,   ["request"] = 8}
+    --             }
+    --         },
+    --         ["Account"] = {
+    --             ["state"] = {
+    --                 ["5"]   = {["timeout"] = 0,    ["request"] = 1}
+    --             },
+    --             ["limits"] = {
+    --                 ["5"]   = {["timeout"] = 60,   ["request"] = 3}
+    --             }
+    --         }
+    --     }
+    -- }
+    self.policies = {}
+    self.retryAfter = {}
+    self.lastUpdate = {}
+    self.requestHistory = {}
+    -- leave this much safety margin on limits for external use (browser, trade app)
+    self.limitMargin = 1
+    -- convenient name lookup, can be extended
+    self.policyNames = {
+        ["search"] = "trade-search-request-limit",
+        ["fetch"] = "trade-fetch-request-limit"
+    }
+    self.delayCache = {}
+    self.requestId = 0
+    -- we are tracking ongoing requests to update the rate limits state when 
+    -- the last request is finished since this is a reliable sync point. (no pending modifications on state)
+    -- Otherwise we are managing our local state and updating only if the response
+    -- state shows more requests than expected (external requests)
+    self.pendingRequests = {
+        ["trade-search-request-limit"] = {},
+        ["trade-fetch-request-limit"] = {}
+    }
+end)
+
+function TradeQueryRateLimiterClass:GetPolicyName(key)
+    return self.policyNames[key]
+end
+
+function TradeQueryRateLimiterClass:ParseHeader(headerString)
+    local headers = {}
+    for k, v in headerString:gmatch("([%a%d%-]+): ([%g ]+)") do
+        if k == nil then error("Unparseable Header") end
+        headers[k] = v
+    end
+    return headers
+end
+
+function TradeQueryRateLimiterClass:ParsePolicy(headerString) 
+    local policies = {}
+    local headers = self:ParseHeader(headerString)
+    local policyName = headers["X-Rate-Limit-Policy"]
+    policies[policyName] = {}
+    local retryAfter = headers["Retry-After"]
+    if retryAfter then
+        policies[policyName].retryAfter = os.time() + retryAfter
+    end
+    local ruleNames = {}
+    for match in headers["X-Rate-Limit-Rules"]:gmatch("[^,]+") do
+        ruleNames[#ruleNames+1] = match
+    end
+    for _, ruleName in pairs(ruleNames) do
+        policies[policyName][ruleName] = {}
+        local properties = {
+            ["limits"] = "X-Rate-Limit-"..ruleName,
+            ["state"] = "X-Rate-Limit-"..ruleName.."-State",
+        }
+        for key, headerKey in pairs(properties) do
+            policies[policyName][ruleName][key] = {}
+            local headerValue = headers[headerKey]
+            for bucket in headerValue:gmatch("[^,]+") do -- example 8:10:60,15:60:120,60:300:1800
+                local next = bucket:gmatch("[^:]+") -- example 8:10:60
+                local request, window, timeout = tonumber(next()), tonumber(next()), tonumber(next())
+                policies[policyName][ruleName][key][window] = {
+                    ["request"] = request,
+                    ["timeout"] = timeout
+                }
+            end
+        end
+    end
+    return policies
+end
+
+function TradeQueryRateLimiterClass:UpdateFromHeader(headerString)
+    local newPolicies = self:ParsePolicy(headerString)
+    for policyKey, policyValue in pairs(newPolicies) do
+        if self.requestHistory[policyKey] == nil then
+            self.requestHistory[policyKey] = { timestamps = {} }
+        end
+        if policyValue.retryAfter then
+            self.retryAfter[policyKey] = policyValue.retryAfter
+            policyValue.retryAfter = nil
+        end
+        if self.limitMargin > 0 then
+            newPolicies = self:ReduceLimits(self.limitMargin, newPolicies)
+        end
+        if self.policies[policyKey] == nil or #self.pendingRequests[policyKey] == 0 then
+            self.policies[policyKey] = policyValue
+        else
+            for rule, ruleValue in pairs(policyValue) do
+                for window, state in pairs(ruleValue.state) do
+                    local oldState = self.policies[policyKey][rule]["state"][window]
+                    if state.request > oldState.request then
+                        oldState.request = state.request
+                    end
+                end
+            end
+        end
+        self.lastUpdate[policyKey] = os.time()
+        -- calculate maxWindow sizes for requestHistory tables
+        local maxWindow = 0
+        for _, rule in pairs(policyValue) do
+            for window, _ in pairs(rule.limits) do
+                maxWindow = math.max(maxWindow, window)
+            end
+        end
+        self.requestHistory[policyKey].maxWindow = maxWindow
+    end
+end
+
+function TradeQueryRateLimiterClass:NextRequestTime(policy, time)
+    local now = time or os.time()
+    local nextTime = now
+    if self.policies[policy] == nil then
+        if self.requestHistory[policy] and #self.requestHistory[policy].timestamps > 0 then
+            -- a request has been made and we are waiting for the response to parse limits, block requests using a long cooldown (PoE2 release date)
+            -- practically blocking indefinitely until rate limits are initialized
+            return 1956528000
+        else
+            -- first request, dont block to acquire rate limits from first response
+            return now
+        end
+    end
+    if self.retryAfter[policy] and self.retryAfter[policy] >= now then
+        nextTime = math.max(nextTime, self.retryAfter[policy])
+        return nextTime
+    end
+    self:AgeOutRequests(policy)
+    for _, rule in pairs(self.policies[policy]) do
+        for window, _ in pairs(rule.limits) do
+            if rule.state[window].timeout > 0 then
+                --an extra second is added to the time calculations here and below in order to avoid problems caused by the low resolution of os.time()
+                nextTime = math.max(nextTime, self.lastUpdate[policy] + rule.state[window].timeout + 1)
+            end
+            if rule.state[window].request >= rule.limits[window].request then
+                -- reached limit, calculate next request time
+                -- find oldest timestamp in window
+                local oldestRequestIdx = 0
+                for _, timestamp in pairs(self.requestHistory[policy].timestamps) do
+                    if timestamp >= now - window then
+                        oldestRequestIdx = oldestRequestIdx + 1
+                    else
+                        break
+                    end
+                end
+                if oldestRequestIdx == 0 then 
+                    -- state reached limit but we dont have any recent timestamps (external factors)
+                    nextTime = math.max(nextTime, self.lastUpdate[policy] + rule.limits[window].timeout + 1)
+                else
+                    -- the expiration time of oldest timestamp in the window
+                    local nextAvailableTime = self.requestHistory[policy].timestamps[oldestRequestIdx] + window + 1
+                    nextTime = math.max(nextTime, nextAvailableTime)
+                end
+            end
+        end
+    end
+    return nextTime
+end
+
+function TradeQueryRateLimiterClass:InsertRequest(policy, timestamp, time)
+    local now = time or os.time()
+    timestamp = timestamp or now
+    if self.requestHistory[policy] == nil then
+        self.requestHistory[policy] = { timestamps = {} }
+    end
+    local insertIndex = 1
+    for i, v in ipairs(self.requestHistory[policy].timestamps) do
+        if timestamp >= v then
+            insertIndex = i
+            break
+        end
+    end
+    table.insert(self.requestHistory[policy].timestamps, insertIndex, timestamp)
+    if self.policies[policy] then
+        for _, rule in pairs(self.policies[policy]) do
+            for _, window in pairs(rule.state) do
+                window.request = window.request + 1
+            end
+        end
+        self.lastUpdate[policy] = now
+    end
+    local requestId = self.requestId
+    self.requestId = self.requestId + 1
+    table.insert(self.pendingRequests[policy], requestId)
+    return requestId 
+end
+
+function TradeQueryRateLimiterClass:FinishRequest(policy, requestId)
+    if self.pendingRequests[policy] then
+        for index, value in ipairs(self.pendingRequests[policy]) do
+            if value == requestId then
+                table.remove(self.pendingRequests[policy], index)
+            end
+        end
+    end
+end
+
+function TradeQueryRateLimiterClass:AgeOutRequests(policy, time)
+    local now = time or os.time()
+    local requestHistory = self.requestHistory[policy]
+    requestHistory.lastCheck = requestHistory.lastCheck or now
+    if (requestHistory.lastCheck == now) then
+        return
+    end
+    for i = #requestHistory.timestamps, 1 , -1 do
+        local timestamp = requestHistory.timestamps[i]
+        for _, rule in pairs(self.policies[policy]) do
+            for window, windowValue in pairs(rule.state) do
+                if timestamp >= (requestHistory.lastCheck - window) and timestamp < (now - window) then
+                    -- timestamp that used to be in the window on last check
+                    windowValue.request = math.max(windowValue.request - 1, 0)
+                end
+            end
+        end
+        if timestamp < now - requestHistory.maxWindow then
+            table.remove(requestHistory.timestamps, i)
+        end
+    end
+    requestHistory.lastCheck = now
+end
+
+-- Reduce limits visible to pob so the user can safely interact with the trade site
+function TradeQueryRateLimiterClass:ReduceLimits(margin, policies)
+    for _, policy in pairs(policies) do
+        for _, rule in pairs(policy) do
+            for _, window in pairs(rule.limits) do
+                window.request = math.max(window.request - margin, 1)
+            end
+        end
+    end
+    return policies
+end

--- a/src/Classes/TradeQueryRequests.lua
+++ b/src/Classes/TradeQueryRequests.lua
@@ -1,0 +1,275 @@
+-- Path of Building
+--
+-- Module: Trade Query Requests
+-- Handling trade api requests while respecting rate limits
+--
+
+local dkjson = require "dkjson"
+
+---@class TradeQueryRequests
+local TradeQueryRequestsClass = newClass("TradeQueryRequests", function(self, rateLimiter)
+    self.rateLimiter = rateLimiter or new("TradeQueryRateLimiter")
+    self.requestQueue = {
+		["search"] = {},
+		["fetch"] = {},
+	}
+	self.maxFetchPerSearch = 20
+end)
+
+---Main routine for processing request queue
+function TradeQueryRequestsClass:ProcessQueue()
+	for key, queue in pairs(self.requestQueue) do
+		if #queue > 0 then
+			local policy = self.rateLimiter:GetPolicyName(key)
+			local now = os.time()
+			local timeNext = self.rateLimiter:NextRequestTime(policy, now)
+			if now >= timeNext then			
+				local request = table.remove(queue, 1)
+				local requestId = self.rateLimiter:InsertRequest(policy)			
+				local onComplete = function(response, errMsg)
+					self.rateLimiter:FinishRequest(policy, requestId)				
+					self.rateLimiter:UpdateFromHeader(response.header)				
+					if response.header:match("HTTP/[%d%.]+ (%d+)") == "429" then
+						table.insert(queue, 1, request)
+						return
+					end
+					request.callback(response.body, errMsg, unpack(request.callbackParams or {}))
+				end
+				self:SendRequest(request.url , onComplete, {body = request.body, poesessid = POESESSID})
+			else
+				break
+			end
+		end
+	end
+end
+
+---@param url string
+---@param callback fun(response:table, errMsg:string) @ response = { header, body }
+---@param params table @ params = { body, poesessid }
+function TradeQueryRequestsClass:SendRequest(url, callback, params)
+	params = params or {}
+	local id = LaunchSubScript([[
+		local curl = require("lcurl.safe")
+		local easy = curl.easy()
+		local url, req_body, versionNumber, POESESSID = ...
+		local res_header = ""
+		local res_body = ""
+        local httpheader = {
+				'User-Agent: Path of Building/' .. versionNumber .. ' (contact: pob@mailbox.org)',
+				'Accept: application/json',
+				'Content-Type: application/json',
+			}
+        if POESESSID then
+            table.insert(httpheader, 'Cookie: POESESSID='..POESESSID)
+        end
+		if req_body then
+			easy:setopt{
+				postfields = req_body,
+				post = true,
+			}
+		end
+		easy:setopt{
+			url = url,
+			httpheader = httpheader,
+		}
+		easy:setopt_headerfunction(function(data)
+			res_header = res_header..data
+			return true
+		end)
+		easy:setopt_writefunction(function(data)
+			res_body = res_body..data
+			return true
+		end)
+		easy:perform()
+		easy:close()
+		return res_header, res_body
+	]], "", "", url, params.body, launch.versionNumber, params.poesessid)
+	if id then
+		launch:RegisterSubScript(id, function(header, body, errMsg)
+			callback({header = header, body = body}, errMsg)
+		end)
+	end
+end
+
+---Performs search and fetches results
+---@param league string
+---@param query string
+---@param callback fun(items:table, errMsg:string)
+---@param params table @ params = { callbackQueryId = fun(queryId:string) }
+function TradeQueryRequestsClass:SearchWithQuery(league, query, callback, params)
+	params = params or {}
+	self:PerformSearch(league, query, function(itemHashes, queryId, errMsg)
+		if errMsg then
+			return callback(nil, errMsg)
+		end
+		if params.callbackQueryId then
+			params.callbackQueryId(queryId)
+		end
+		self:FetchResults(itemHashes, queryId, callback)
+	end)
+end
+
+---Perform search and run callback function on returned item hashes.
+---Item info has to be fetched seperately 
+---@param league string
+---@param query string
+---@param callback fun(itemHashes:string[], queryId:string, errMsg:string)
+function TradeQueryRequestsClass:PerformSearch(league, query, callback)
+	table.insert(self.requestQueue["search"], {
+		url = "https://www.pathofexile.com/api/trade/search/"..league,
+		body = query,
+		callback = function(response, errMsg)
+			if errMsg then
+				return callback(nil, nil, errMsg)
+			end
+			local response = dkjson.decode(response)
+			if not response then
+				errMsg =  "Failed to Get Trade response"
+				return callback(nil, nil, errMsg)
+			end
+			if not response.result or #response.result == 0 then
+				if response.error then
+					if response.error.code == 2 then
+						errMsg = "Complex Query - Please provide your POESESSID"
+					elseif response.error.message then
+						errMsg = response.error.message
+					end
+				else
+					errMsg = "No Matching Results Found"
+				end
+				return callback(nil, nil, errMsg)
+			end
+			callback(response.result, response.id, errMsg)
+		end,
+	})
+end
+
+---Fetch item details for itemHashes
+---@param itemHashes string[]
+---@param queryId string
+---@param callback fun(items:table, errMsg:string)
+function TradeQueryRequestsClass:FetchResults(itemHashes, queryId, callback)
+	local quantity_found = math.min(#itemHashes, self.maxFetchPerSearch)
+	local max_block_size = 10
+	local items = {}
+	for fetch_block_start = 1, quantity_found, max_block_size do
+		local fetch_block_end = math.min(fetch_block_start + max_block_size - 1, quantity_found)
+		local param_item_hashes = table.concat({unpack(itemHashes, fetch_block_start, fetch_block_end)}, ",")
+		local fetch_url = "https://www.pathofexile.com/api/trade/fetch/"..param_item_hashes.."?query="..queryId
+		self:FetchResultBlock(fetch_url, function(itemBlock, errMsg)
+			if errMsg then
+				return callback(nil, errMsg)
+			end
+			for _, item in pairs(itemBlock) do
+				table.insert(items, item)
+			end
+			-- finished fetching item blocks
+			if #items == quantity_found then
+				callback(items)
+			end
+		end)
+	end
+end
+
+---Fetch details for paginated items
+---@param url string
+---@param callback fun(items: table, errMsg:string)
+function TradeQueryRequestsClass:FetchResultBlock(url, callback)
+	table.insert(self.requestQueue["fetch"], {
+		url = url,
+		callback = function(response, errMsg)
+			if errMsg then
+				return callback(nil, errMsg)
+			end
+			local response, response_err = dkjson.decode(response)
+			if not response or not response.result then
+				local errMsg
+				if response_err then
+					errMsg = "JSON Parse Error "
+				else
+					errMsg = "Failed to Get Trade Items"
+				end
+				return callback(nil, errMsg)
+			end
+			local items = {}
+			for _, trade_entry in pairs(response.result) do
+				table.insert(items, {
+					amount = trade_entry.listing.price.amount,
+					currency = trade_entry.listing.price.currency,
+					item_string = common.base64.decode(trade_entry.item.extended.text),
+					whisper = trade_entry.listing.whisper,
+				})
+			end
+			return callback(items)
+		end
+	})
+end
+
+---@param callback fun(items:table, errMsg:string)
+function TradeQueryRequestsClass:SearchWithURL(url, callback)
+	local league, queryId = url:match("https://www.pathofexile.com/trade/search/(.+)/(.+)$")
+	-- self:FetchSearchQuery(queryId,
+	-- testing experimental HTML parsing
+	self:FetchSearchQueryHTML(queryId, function(query, errMsg)
+		if errMsg then
+			return callback(nil, errMsg)
+		end
+		self:SearchWithQuery(league, query, callback)
+	end)
+end
+
+---Fetch query data needed to perform the search
+---@param queryId string
+---@param callback fun(query:string, errMsg:string)
+function TradeQueryRequestsClass:FetchSearchQuery(queryId, callback)
+	local url = "https://www.pathofexile.com/api/trade/search/" .. queryId
+	table.insert(self.requestQueue["search"], {
+		url = url,
+		callback = function(response, errMsg)
+			if errMsg then
+				return callback(nil, errMsg)
+			end
+			local json_data = dkjson.decode(response)
+			if not json_data or json_data.error then
+				errMsg = json_data and json_data.error or "Failed to get search query"
+			end
+			callback(response, errMsg)
+		end
+	})
+end
+
+---EXPERIMENTAL HTML parsing to circumvent extra API call for query fetching
+--- queryId -> query fetching via Poe API call costs precious search requests
+--- But the search page HTML also contains the query object and this request is not throttled
+---@param queryId string
+---@param callback fun(query:string, errMsg:string)
+---@see TradeQueryRequests#FetchSearchQuery
+function TradeQueryRequestsClass:FetchSearchQueryHTML(queryId, callback)
+	-- the league doesn't affect query so we set it to Standard as it doesn't change
+	self:DownloadPage("https://www.pathofexile.com/trade/search/Standard/" .. queryId, 
+		function(response, ErrMsg)
+			if ErrMsg then
+				return callback(nil, ErrMsg)
+			end
+			-- full json state obj from HTML
+			local dataStr = response:match('require%(%["main"%].+ t%((.+)%);}%);}%);')
+			if not dataStr then
+				return callback(nil, "JSON object not found on the page.")
+			end
+			local data, _, err = dkjson.decode(dataStr)
+			if err then
+				return callback(nil, "Failed to parse JSON object. ".. err)
+			end
+			local query = {query = data.state}
+			query.sort = {price = "asc"}
+			query.query.status = { option = query.query.status} -- works either way?
+			local queryStr = dkjson.encode(query)
+			callback(queryStr, ErrMsg)
+		end)
+end
+
+function TradeQueryRequestsClass:DownloadPage(url, callback)
+	self:SendRequest(url, function(response, errMsg)
+		callback(response.body, errMsg)
+	end)
+end


### PR DESCRIPTION
Big commit. To sum it up:
- added a rate-limiter module that stays in sync with Trade API
- moved API requests into its own module to clean up UI code 
- added a function to fetch currency short names from Poe API instead of statically including them
- added a function to get search query by parsing search page HTML instead of API call to reduce API requests

There is some error checking but more wouldn't hurt.
Also, input validation and some indicators for queue state and timeouts would be nice, I didn't touch UI stuff.